### PR TITLE
Fixes bug to prevent double page scroll

### DIFF
--- a/jquery.multiscroll.js
+++ b/jquery.multiscroll.js
@@ -174,7 +174,7 @@
 
 				var isFirstScrollMove = (typeof lastScrolledDestiny === 'undefined' );
 
-				if (isFirstScrollMove || sectionAnchor !== lastScrolledDestiny){
+				if (isFirstScrollMove || sectionAnchor !== lastScrolledDestiny.toString()){
 					scrollPage(section);
 				}
 			}


### PR DESCRIPTION
We had a problem where `afterLoad` was called twice. I believe this commit fixes a minor bug where the if expression would always be false (`sectionAnchor` is a string and `lastScrollDestiny` is a number).

After this commit, our `afterLoad` is only called once, as expected.
