### PR TITLE
Added a step to clone left side content to right side as an alternati…

### DIFF
--- a/jquery.multiscroll.css
+++ b/jquery.multiscroll.css
@@ -16,6 +16,7 @@ html, body {
     -webkit-box-sizing: border-box;
     -moz-box-sizing: border-box;
     box-sizing: border-box;
+    overflow:hidden;
 }
 .ms-section.ms-table{
     display: table;
@@ -32,6 +33,13 @@ html, body {
     -moz-transition: all 0.7s ease-out;
     -o-transition: all 0.7s ease-out;
     transition: all 0.7s ease-out;
+}
+.ms-fullscreen-content{
+    width:200%;
+    box-sizing:border-box;
+}
+.ms-fullscreen-right .ms-fullscreen-content{
+    margin-left:-100%;
 }
 #multiscroll-nav {
     position: fixed;

--- a/jquery.multiscroll.js
+++ b/jquery.multiscroll.js
@@ -121,6 +121,11 @@
 		$('.ms-left .ms-section, .ms-right .ms-section').each(function(){
 			var sectionIndex = $(this).index();
 
+            //clone left side to right if the right side is empty
+            if( $(this).hasClass('ms-fullscreen-right') ){
+                $(this).empty().append( $('.ms-left .ms-section')[sectionIndex].innerHTML );
+            }
+
 			if(options.paddingTop || options.paddingBottom){
 				$(this).css('padding', options.paddingTop  + ' 0 ' + options.paddingBottom + ' 0');
 			}


### PR DESCRIPTION
Added a step to clone left side content to right side as an alternative way to generate fullscreen slides. CSS hides/aligns potentially overlapping content.

In the html markup, tag the frames to be cloned with classes like so:
```html
<div class="ms-section third ms-fullscreen-left" id="left3">
     <div class='ms-fullscreen-content'>
         :
     </div>
</div>

<div class="ms-section third ms-fullscreen-right" id="right3"></div>
```
class "ms-fullscreen-left" is effectively a do-nothing class, but it gives a visual indication to the developer that this content is going to be cloned across the whole browser window.

Thank you for this plugin - it was just what I needed when making an online sales brochure.